### PR TITLE
26 라우터 경로 수정

### DIFF
--- a/src/components/common/bottomTab/BottomTab.jsx
+++ b/src/components/common/bottomTab/BottomTab.jsx
@@ -70,7 +70,6 @@ const Tab = ({ img, imgSelected, title, setSelected, isSelected }) => {
   }, [location.pathname, setSelected]);
 
   const onClickFn = () => {
-    if (isSelected) return;
     navigate(`/${tabs[title]}`);
   };
   return (

--- a/src/components/common/topBar/TopBarComponents.jsx
+++ b/src/components/common/topBar/TopBarComponents.jsx
@@ -14,7 +14,7 @@ export const LogoWithNotification = () => {
       <img
         src={logo}
         className="w-[10vw] max-w-10 hover:cursor-pointer"
-        onClick={() => navigate("/home")}
+        onClick={() => navigate("/")}
       />
       <img
         src={noti}

--- a/src/components/manage/MoreServiceComponent.jsx
+++ b/src/components/manage/MoreServiceComponent.jsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 // icons
 import rightCircleArrow from "../../assets/icons/rightCircleArrow.svg";
 
 export default function MoreServiceComponent({ title, detail }) {
+  const navigate = useNavigate();
   return (
     <div className="w-full h-[10vh] flex items-center justify-between px-5 py-3 bg-[#FFEDB3] rounded-[30px]">
       <div className="flex flex-col">
@@ -12,7 +14,13 @@ export default function MoreServiceComponent({ title, detail }) {
           <span className="text-[12px] text-[#505050]">{detail}</span>
         </div>
       </div>
-      <img src={rightCircleArrow} className="w-[50px] hover:cursor-pointer" />
+      <img
+        src={rightCircleArrow}
+        className="w-[50px] hover:cursor-pointer"
+        onClick={() =>
+          navigate(`${title === "노후준비종합진단" ? "diagnosis" : "pension"}`)
+        }
+      />
     </div>
   );
 }

--- a/src/routers/mainRouter.jsx
+++ b/src/routers/mainRouter.jsx
@@ -95,7 +95,7 @@ export const mainRouter = [
             index: true,
           },
           {
-            path: "rebalancingList",
+            path: "rebalancing-list",
             element: <RebalancingListPage />,
             index: true,
           },

--- a/src/routes/home/HomePage.jsx
+++ b/src/routes/home/HomePage.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 // icons
 import downArrow from "../../assets/icons/downArrow.svg";
@@ -11,6 +12,7 @@ import Tab from "../../components/home/TabComponent";
 import RobotAnalyzing from "../../components/home/RobotAnalyzing";
 
 export default function HomePage() {
+  const navigate = useNavigate();
   const [isSelected, setSelected] = useState(0);
   const [isLogin, setIsLogin] = useState(false);
   const [isTestFinished, setIsTestFinished] = useState(false);
@@ -44,7 +46,10 @@ export default function HomePage() {
                   <span className="font-bold">초개인화 포트폴리오를 추천</span>
                   받을 수 있어요!
                 </div>
-                <button className="bg-main_yellow rounded-[20px] box-content px-5 py-1 ml-2 text-[10px]">
+                <button
+                  className="bg-main_yellow rounded-[20px] box-content px-5 py-1 ml-2 text-[10px]"
+                  onClick={() => navigate("/invest-test")}
+                >
                   테스트 하러가기
                 </button>
               </div>
@@ -85,7 +90,10 @@ export default function HomePage() {
                 </div>
                 <div className="absolute inset-0 flex justify-center items-center flex-col text-[20px]">
                   로그인 후 이용 가능합니다.
-                  <button className="bg-main_yellow px-10 py-2 rounded-[20px] mt-5 text-[15px]">
+                  <button
+                    className="bg-main_yellow px-10 py-2 rounded-[20px] mt-5 text-[15px]"
+                    onClick={() => navigate("/login")}
+                  >
                     로그인
                   </button>
                 </div>


### PR DESCRIPTION
* 리밸런싱 목록 조회 페이지 path 수정 (`rebalancingList` -> `rebalancing-list`)
* 포트폴리오 추천 상세 조회 페이지 투자 성향 진단 테스트, 로그인 버튼에 라우터 연결
* 하단 바 각 탭 클릭 시, 메인 페이지로의 이동 막는 코드 `(if (isSelected) return;)` 제거
* 상단 바 로고 클릭 시, 이동 path 수정 (`"/home"` -> `"/"`)
* 노후준비종합진단, 미청구 퇴직연금 조회 라우터 연결